### PR TITLE
Add negated molecular function shape.

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -75,12 +75,16 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
 } // rdfs:comment  "A biological process"
 
 
-<MolecularFunctionClass> @<OwlClass> AND {
+<MolecularFunctionClass> IRI @<OwlClass> AND {
   rdfs:subClassOf [ GoMolecularFunction: ] ;
 }
 
+<NegatedMolecularFunctionClass> @<OwlClass> AND {
+  owl:complementOf @<MolecularFunctionClass>
+}
+
 <MolecularFunction> @<GoCamEntity> AND EXTRA a {
-  a @<MolecularFunctionClass> {1};
+  a ( @<MolecularFunctionClass> OR @<NegatedMolecularFunctionClass> ) {1};
   enabled_by:  ( @<Protein> OR @<Complex> ) {0,1};
   part_of: @<BiologicalProcess> {0,1};
   occurs_in: @<CellularComponent> {0,1};

--- a/test_ttl/go_cams/should_pass/test-negation1.ttl
+++ b/test_ttl/go_cams/should_pass/test-negation1.ttl
@@ -1,0 +1,104 @@
+@prefix : <http://model.geneontology.org/5d29218800000021#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://model.geneontology.org/5d29218800000021> .
+
+<http://model.geneontology.org/5d29218800000021> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/5d29218800000021> ;
+                                                  owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
+                                                  <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/title> "Test model with negation"^^xsd:string ;
+                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://geneontology.org/lego/evidence
+<http://geneontology.org/lego/evidence> rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://model.geneontology.org/5d29218800000021/5d29218800000022
+<http://model.geneontology.org/5d29218800000021/5d29218800000022> rdf:type owl:NamedIndividual ,
+                                                                           <http://identifiers.org/zfin/ZDB-GENE-980526-388> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+
+###  http://model.geneontology.org/5d29218800000021/5d29218800000023
+<http://model.geneontology.org/5d29218800000021/5d29218800000023> rdf:type owl:NamedIndividual ,
+                                                                           [ rdf:type owl:Class ;
+                                                                             owl:complementOf <http://purl.obolibrary.org/obo/GO_0005158>
+                                                                           ] ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d29218800000021/5d29218800000022> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/5d29218800000021/5d29218800000023> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d29218800000021/5d29218800000022> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d29218800000021/5d29218800000024> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/5d29218800000021/5d29218800000024
+<http://model.geneontology.org/5d29218800000021/5d29218800000024> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0000303> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "PMID:12345"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+
+###  http://model.geneontology.org/5d29218800000021/5d29218800000025
+<http://model.geneontology.org/5d29218800000021/5d29218800000025> rdf:type owl:NamedIndividual ,
+                                                                           <http://identifiers.org/zfin/ZDB-GENE-980526-388> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+
+###  http://model.geneontology.org/5d29218800000021/5d29218800000026
+<http://model.geneontology.org/5d29218800000021/5d29218800000026> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/GO_0004096> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d29218800000021/5d29218800000025> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/5d29218800000021/5d29218800000026> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d29218800000021/5d29218800000025> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d29218800000021/5d29218800000027> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/5d29218800000021/5d29218800000027
+<http://model.geneontology.org/5d29218800000021/5d29218800000027> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0000303> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-8688-6599"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2019-07-16"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "PMID:12345"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+
+###  Generated by the OWL API (version 4.2.8) https://github.com/owlcs/owlapi


### PR DESCRIPTION
I added a shape for negated molecular function. I also restricted the existing MolecularFunctionClass to be `IRI`. I added a test file, but I don't think the negated molecular function is actually being checked yet by the python validator.

I'm not sure whether it's best to use `OR` for the value of the `type` triple pattern; or if instead it should be two patterns with a choice (`|`) operator. See [Example 77: Difference between Or and |](http://book.validatingrdf.com/bookHtml010.html#sec103). Probably `|` is more correct, but I went with the pattern in place elsewhere in the file.