### PR TITLE
WIP: adding information biomacromolecule type

### DIFF
--- a/python/gocam_validator.py
+++ b/python/gocam_validator.py
@@ -25,6 +25,7 @@ cmap = {
     "http://purl.obolibrary.org/obo/GO_0008150" : "BiologicalProcess",
     "http://purl.obolibrary.org/obo/GO_0005575" : "CellularComponent",
     "http://purl.obolibrary.org/obo/CHEBI_36080" : "Protein",
+    "http://purl.obolibrary.org/obo/CHEBI_33695" : "InformationBiomacromolecule",
 
     "http://purl.obolibrary.org/obo/ECO_0000000" : "Evidence"
 }

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -11,6 +11,7 @@ PREFIX date: <http://purl.org/dc/elements/1.1/date>
 PREFIX xref: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
 PREFIX exact_match: <http://www.w3.org/2004/02/skos/core#exactMatch>
 #semantic: classes
+PREFIX GoInformationBiomacromolecule: <http://purl.obolibrary.org/obo/CHEBI_33695>
 PREFIX GoProtein: <http://purl.obolibrary.org/obo/CHEBI_36080>
 PREFIX GoCellularComponent: <http://purl.obolibrary.org/obo/GO_0005575>
 PREFIX GoBiologicalProcess: <http://purl.obolibrary.org/obo/GO_0008150>
@@ -85,7 +86,7 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
 
 <MolecularFunction> @<GoCamEntity> AND EXTRA a {
   a ( @<MolecularFunctionClass> OR @<NegatedMolecularFunctionClass> ) {1};
-  enabled_by:  ( @<Protein> OR @<Complex> ) {0,1};
+  enabled_by:  ( @<Protein> OR @<Complex> OR @<InformationBiomacromolecule> ) {0,1};
   part_of: @<BiologicalProcess> {0,1};
   occurs_in: @<CellularComponent> {0,1};
   has_output: @<MolecularEntity> *;
@@ -159,6 +160,15 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
    a @<ProteinClass> ;
    located_in: @<CellularComponent> {0,1};
 }// rdfs:comment  "a protein"
+
+
+<InformationBiomacromoleculeClass> @<OwlClass> AND {
+  rdfs:subClassOf [ GoInformationBiomacromolecule: ];
+}
+<InformationBiomacromolecule> @<MolecularEntity> AND EXTRA a {
+   a @<InformationBiomacromoleculeClass> ;
+   located_in: @<CellularComponent> {0,1};
+}// rdfs:comment  "an information biomacromolecule - e.g. a protein or RNA product"
 
 <ChemicalEntity> EXTRA bl:category{
 }// rdfs:comment  "a chemical entity"

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -170,7 +170,7 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
 }// rdfs:comment  "a protein"
 
 
-<InformationBiomacromoleculeClass> @<OwlClass> AND {
+<InformationBiomacromoleculeClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
   rdfs:subClassOf [ GoInformationBiomacromolecule: ];
 }
 <InformationBiomacromolecule> @<MolecularEntity> AND EXTRA a {


### PR DESCRIPTION
See #26

Note that currently in NEO RNA central IDs are treated simply as information biomacromolecules

This doesn't seem to be working at the moment, I think we are making the assumption that XClass has a single subClassOf (inferred) which causes issues with hierarchies eg

```
  Testing <http://model.geneontology.org/8> against shape N0715d8fc652849aba11eb0ddf94872e9
    Testing uniprot:P12643 against shape N92fec8ecf9cf41669d3c70cc9aba0ee1
      Triples:
      uniprot:P12643 rdfs:subClassOf obo:CHEBI_33695 .
      uniprot:P12643 rdfs:subClassOf obo:CHEBI_36080 .
   2 triples exceeds max {1,1}
```