### PR TITLE
Adding has_input and has_output to Biological Process

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -76,6 +76,8 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
 <BiologicalProcess> @<GoCamEntity> AND EXTRA a {
   a ( @<BiologicalProcessClass> OR @<NegatedBiologicalProcessClass> ) {1};
   part_of: @<BiologicalProcess> {0,1};
+  has_input: ( @<MolecularEntity> OR @<AnatomicalEntity> ) *;
+  has_output: ( @<MolecularEntity> OR @<AnatomicalEntity> ) *;
 } // rdfs:comment  "A biological process"
 
 


### PR DESCRIPTION
To allow for molecular inputs and outputs to activity-regulating processes as well as things like anatomical entity inputs and outputs to development processes.