### PR TITLE
Update go-cam-shapes.shex

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -226,6 +226,7 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
 <InformationBiomacromolecule> @<ChemicalEntity> AND EXTRA a {
    a @<InformationBiomacromoleculeClass> ;
    located_in: @<CellularComponent> {0,1};
+   part_of: @<ProteinContainingComplex> {0,1};
 }// rdfs:comment  "an information biomacromolecule - e.g. a protein or RNA product"
 
 <EvidenceClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {


### PR DESCRIPTION
Adding that an InformationBiomacromolecule can be part_of a protein-containing complex for MOD imports.
See discussion here:
https://github.com/geneontology/gocamgen/issues/25