### PR TITLE
transport could apply to entities aside from abstract genes, right?

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -89,7 +89,7 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
   has_input: ( @<ChemicalEntity> OR @<AnatomicalEntity> ) *;
   has_output: ( @<ChemicalEntity> OR @<AnatomicalEntity> ) *;
   occurs_in: ( @<AnatomicalEntity> ) {0,1};
-  transports_or_maintains_localization_of: @<InformationBiomacromolecule> *;
+  transports_or_maintains_localization_of: ( @<ChemicalEntity> OR @<AnatomicalEntity> ) *;
   has_target_end_location: @<AnatomicalEntity> {0,1};
   has_target_start_location: @<AnatomicalEntity> {0,1};
   causally_upstream_of: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;


### PR DESCRIPTION
Came up in the context of reactome conversion modeling. Suggesting change to BP shape:


transports_or_maintains_localization_of: ( `@<ChemicalEntity>` OR `@<AnatomicalEntity>` ) *;