### PR TITLE
this cures a reasoner-shex odd interaction

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -222,7 +222,7 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
   rdfs:subClassOf [ GoInformationBiomacromolecule: ];
 }
 <InformationBiomacromolecule> @<ChemicalEntity> AND EXTRA a {
-   a @<InformationBiomacromoleculeClass> ;
+   a @<InformationBiomacromoleculeClass> +;
    part_of: @<CellularComponent> {0,1};
    part_of: @<ProteinContainingComplex> {0,1};
 }// rdfs:comment  "an information biomacromolecule - e.g. a protein or RNA product"


### PR DESCRIPTION
Fixes https://github.com/geneontology/go-shapes/issues/173
Basically, the reasoner infers that more than one of the types of a given object (typically an enabler) are InformationBiomacromolecules.  We need to allow that to happen by opening up the cardinality on the constraint with the addition of +.
a @<InformationBiomacromoleculeClass> +;