### PR TITLE
Update go-cam-shapes.shex - first BP term-specific shape

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -106,8 +106,8 @@ PREFIX results_in_development_of: <http://purl.obolibrary.org/obo/RO_0002296>
 	rdfs:subClassOf [ GoAnatomicalStructureDevelopment: ] ;
 
 <AnatomicalStructureDevelopment> @<BiologicalProcess> AND EXTRA a {
-  a @<AnatomicalStructureDevelopmentClass>; {1}
-  results_in_development_of: @<AnatomicalEntity> {0,1};  
+  a @<AnatomicalStructureDevelopmentClass> {1};
+  results_in_development_of: @<AnatomicalEntity> {0,1};
 } // rdfs:comment "an anatomical structure development class GO biological process or child”
 
 

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -20,6 +20,7 @@ PREFIX GoProtein: <http://purl.obolibrary.org/obo/CHEBI_36080>
 PREFIX GoProteinContainingComplex: <http://purl.obolibrary.org/obo/GO_0032991>
 PREFIX GoCellularComponent: <http://purl.obolibrary.org/obo/GO_0005575>
 PREFIX GoBiologicalProcess: <http://purl.obolibrary.org/obo/GO_0008150>
+PREFIX GoAnatomicalStructureDevelopment: <http://purl.obolibrary.org/obo/GO_0048856>
 PREFIX GoMolecularFunction: <http://purl.obolibrary.org/obo/GO_0003674>
 PREFIX GoChemicalEntity: <http://purl.obolibrary.org/obo/CHEBI_24431>
 PREFIX GoEvidence: <http://purl.obolibrary.org/obo/ECO_0000000>
@@ -56,6 +57,7 @@ PREFIX causally_upstream_of_or_within_positive_effect: <http://purl.obolibrary.o
 PREFIX causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002411>
 PREFIX causally_upstream_of_negative_effect: <http://purl.obolibrary.org/obo/RO_0002305>
 PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_0002304>
+PREFIX results_in_development_of: <http://purl.obolibrary.org/obo/RO_0002296>
 
 <ProvenanceAnnotated> {
   contributor: xsd:string *; #TODO would be better as an IRI
@@ -99,6 +101,14 @@ PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_
   negatively_regulates: @<BiologicalProcess> *;
   positively_regulates: @<BiologicalProcess> *;
 } // rdfs:comment  "A biological process"
+
+<AnatomicalStructureDevelopmentClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+	rdfs:subClassOf [ GoAnatomicalStructureDevelopment: ] ;
+
+<AnatomicalStructureDevelopment> @<BiologicalProcess> AND EXTRA a {
+  a @<AnatomicalStructureDevelopmentClass>; {1}
+  results_in_development_of: @<AnatomicalEntity> {0,1};  
+} // rdfs:comment "an anatomical structure development class GO biological process or child”
 
 
 <MolecularFunctionClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -108,7 +108,7 @@ PREFIX results_in_development_of: <http://purl.obolibrary.org/obo/RO_0002296>
 <AnatomicalStructureDevelopment> @<BiologicalProcess> AND EXTRA a {
   a @<AnatomicalStructureDevelopmentClass> {1};
   results_in_development_of: @<AnatomicalEntity> {0,1};
-} // rdfs:comment  "an anatomical structure development class GO biological process or child"  
+} // rdfs:comment "an anatomical structure development class GO biological process or child"
 
 <MolecularFunctionClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
   rdfs:subClassOf [ GoMolecularFunction: ] ;

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -108,8 +108,7 @@ PREFIX results_in_development_of: <http://purl.obolibrary.org/obo/RO_0002296>
 <AnatomicalStructureDevelopment> @<BiologicalProcess> AND EXTRA a {
   a @<AnatomicalStructureDevelopmentClass> {1};
   results_in_development_of: @<AnatomicalEntity> {0,1};
-} // rdfs:comment "an anatomical structure development class GO biological process or child”
-
+} // rdfs:comment  "an anatomical structure development class GO biological process or child"  
 
 <MolecularFunctionClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
   rdfs:subClassOf [ GoMolecularFunction: ] ;

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -102,8 +102,10 @@ PREFIX results_in_development_of: <http://purl.obolibrary.org/obo/RO_0002296>
   positively_regulates: @<BiologicalProcess> *;
 } // rdfs:comment  "A biological process"
 
+
 <AnatomicalStructureDevelopmentClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
 	rdfs:subClassOf [ GoAnatomicalStructureDevelopment: ] ;
+}
 
 <AnatomicalStructureDevelopment> @<BiologicalProcess> AND EXTRA a {
   a @<AnatomicalStructureDevelopmentClass> {1};


### PR DESCRIPTION
This is the first BP-specific shape entry, using 'anatomical structure development' as the test run.

I added prefixes for the GO term and the corresponding RO term, as well as the shapes.

I haven't yet added the SPARQL.

@good - if you could review and let me know if things look okay or we need to make any changes before I continue on with adding more shapes, that'd be great.  Thanks.