### PR TITLE
fixing redundant model iris

### DIFF
--- a/test_ttl/go_cams/should_fail/fail_causal_inconsistent_5.ttl
+++ b/test_ttl/go_cams/should_fail/fail_causal_inconsistent_5.ttl
@@ -1,17 +1,17 @@
-@prefix : <http://model.geneontology.org/59dc728000000510#> .
+@prefix : <http://model.geneontology.org/59dc728000000511#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/59dc728000000510> .
+@base <http://model.geneontology.org/59dc728000000511> .
 
-<http://model.geneontology.org/59dc728000000510> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000510> ;
+<http://model.geneontology.org/59dc728000000511> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000511> ;
                                                  # owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/pav/providedBy> "http://purl.obolibrary.org/go/groups/IntAct"^^xsd:string ;
-                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000510"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000511"^^xsd:string ;
                                                   rdfs:comment "Ignore this model if you are looking for data"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "Ben's stable demos"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -71,8 +71,8 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00000266
-<http://model.geneontology.org/59dc728000000510/5ce58dde00000266> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00000266
+<http://model.geneontology.org/59dc728000000511/5ce58dde00000266> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "206"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "391"^^xsd:string ;
@@ -81,8 +81,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002086
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002086> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002086
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002086> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0097325> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "403"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "51"^^xsd:string ;
@@ -91,8 +91,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002088
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002088> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002088
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002088> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -100,8 +100,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002093
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002093> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002093
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002093> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -109,8 +109,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002094
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002094> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002094
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002094> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -118,8 +118,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002095
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002095> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002095
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002095> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/P41587> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "860.75"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "177"^^xsd:string ;
@@ -128,12 +128,12 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002096
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002096> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002096
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002096> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0048018> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00002097> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/5ce58dde00002095> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000511/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000511/5ce58dde00002097> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000511/5ce58dde00002095> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "643"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "287"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -141,37 +141,37 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/5ce58dde00002096> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00002086> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/5ce58dde00002096> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002097> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002098> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00002097> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002098> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/5ce58dde00002096> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002095> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002099> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00002095> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002099> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002097
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002097> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002097
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002097> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "753"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "460"^^xsd:string ;
@@ -180,8 +180,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002098
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002098> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002098
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002098> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -189,8 +189,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002099
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002099> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002099
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002099> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -198,8 +198,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002101
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002101> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002101
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002101> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -207,13 +207,13 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000520
-<http://model.geneontology.org/59dc728000000510/59dc728000000520> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/59dc728000000520
+<http://model.geneontology.org/59dc728000000511/59dc728000000520> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0016874> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/59dc728000000510/5ce58dde00002097> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000511/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000511/5ce58dde00000266> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000511/59dc728000000521> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/59dc728000000511/5ce58dde00002097> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "170"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "236"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -222,48 +222,48 @@
                                                                                                    "http://purl.obolibrary.org/go/groups/BHF-UCL"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002088> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00002086> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002088> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002093> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00000266> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002093> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002094> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/59dc728000000521> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002094> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002097> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002101> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00002097> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002101> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000521
-<http://model.geneontology.org/59dc728000000510/59dc728000000521> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/59dc728000000521
+<http://model.geneontology.org/59dc728000000511/59dc728000000521> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/Q13253> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "54.75"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "111"^^xsd:string ;

--- a/test_ttl/go_cams/should_fail/fail_enabled_by_3.ttl
+++ b/test_ttl/go_cams/should_fail/fail_enabled_by_3.ttl
@@ -1,17 +1,17 @@
-@prefix : <http://model.geneontology.org/59dc728000000510#> .
+@prefix : <http://model.geneontology.org/59dc728000000513#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/59dc728000000510> .
+@base <http://model.geneontology.org/59dc728000000513> .
 
-<http://model.geneontology.org/59dc728000000510> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000510> ;
+<http://model.geneontology.org/59dc728000000513> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000513> ;
                                                #   owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/pav/providedBy> "http://purl.obolibrary.org/go/groups/IntAct"^^xsd:string ;
-                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000510"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000513"^^xsd:string ;
                                                   rdfs:comment "Ignore this model if you are looking for data"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "Ben's stable demos"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -71,8 +71,8 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00000266
-<http://model.geneontology.org/59dc728000000510/5ce58dde00000266> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/5ce58dde00000266
+<http://model.geneontology.org/59dc728000000513/5ce58dde00000266> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "511"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "237"^^xsd:string ;
@@ -81,8 +81,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002086
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002086> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/5ce58dde00002086
+<http://model.geneontology.org/59dc728000000513/5ce58dde00002086> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0097325> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "164"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "46"^^xsd:string ;
@@ -91,8 +91,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002088
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002088> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/5ce58dde00002088
+<http://model.geneontology.org/59dc728000000513/5ce58dde00002088> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -100,8 +100,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002090
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002090> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/5ce58dde00002090
+<http://model.geneontology.org/59dc728000000513/5ce58dde00002090> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -109,8 +109,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002091
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002091> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/5ce58dde00002091
+<http://model.geneontology.org/59dc728000000513/5ce58dde00002091> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -118,11 +118,11 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000520
-<http://model.geneontology.org/59dc728000000510/59dc728000000520> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/59dc728000000520
+<http://model.geneontology.org/59dc728000000513/59dc728000000520> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0016874> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000513/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000513/5ce58dde00000266> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "129"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "250"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -131,30 +131,30 @@
                                                                                                    "http://purl.obolibrary.org/go/groups/BHF-UCL"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000513/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002088> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000513/5ce58dde00002086> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000513/5ce58dde00002088> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000513/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002091> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000513/5ce58dde00000266> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000513/5ce58dde00002091> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000521
-<http://model.geneontology.org/59dc728000000510/59dc728000000521> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000513/59dc728000000521
+<http://model.geneontology.org/59dc728000000513/59dc728000000521> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/Q13253> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000513/5ce58dde00000266> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "468.75"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "75"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -163,10 +163,10 @@
                                                                                                    "http://purl.obolibrary.org/go/groups/BHF-UCL"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000513/59dc728000000521> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002090> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000513/5ce58dde00000266> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000513/5ce58dde00002090> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string

--- a/test_ttl/go_cams/should_fail/fail_part_of_1.ttl
+++ b/test_ttl/go_cams/should_fail/fail_part_of_1.ttl
@@ -1,17 +1,17 @@
-@prefix : <http://model.geneontology.org/59dc728000000510#> .
+@prefix : <http://model.geneontology.org/59dc728000000512#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/59dc728000000510> .
+@base <http://model.geneontology.org/59dc728000000512> .
 
-<http://model.geneontology.org/59dc728000000510> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000510> ;
+<http://model.geneontology.org/59dc728000000512> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000512> ;
                                                #   owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/pav/providedBy> "http://purl.obolibrary.org/go/groups/IntAct"^^xsd:string ;
-                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000510"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000512"^^xsd:string ;
                                                   rdfs:comment "Ignore this model if you are looking for data"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "Ben's stable demos"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -71,16 +71,16 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00000266
-<http://model.geneontology.org/59dc728000000510/5ce58dde00000266> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00000266
+<http://model.geneontology.org/59dc728000000512/5ce58dde00000266> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-05-31"^^xsd:string ;
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002086
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002086> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002086
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002086> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005829> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "323"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "82"^^xsd:string ;
@@ -89,8 +89,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002087
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002087> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002087
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002087> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -98,8 +98,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002088
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002088> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002088
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002088> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -107,8 +107,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002089
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002089> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002089
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002089> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -116,12 +116,12 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000520
-<http://model.geneontology.org/59dc728000000510/59dc728000000520> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/59dc728000000520
+<http://model.geneontology.org/59dc728000000512/59dc728000000520> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0016874> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000512/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000512/5ce58dde00000266> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000512/59dc728000000521> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "129"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "197"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -130,30 +130,30 @@
                                                                                                    "http://purl.obolibrary.org/go/groups/BHF-UCL"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002088> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00002086> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002088> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002087> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00000266> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002087> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002089> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/59dc728000000521> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002089> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string ,
@@ -161,8 +161,8 @@
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000521
-<http://model.geneontology.org/59dc728000000510/59dc728000000521> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/59dc728000000521
+<http://model.geneontology.org/59dc728000000512/59dc728000000521> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/Q13253> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2017-12-20"^^xsd:string ;

--- a/test_ttl/go_cams/should_pass/Test018-directly_positively_regulates_MolecularFunction.ttl
+++ b/test_ttl/go_cams/should_pass/Test018-directly_positively_regulates_MolecularFunction.ttl
@@ -1,13 +1,13 @@
-@prefix : <http://model.geneontology.org/5d27d1cf00000406#> .
+@prefix : <http://model.geneontology.org/5d27d1cf00000407#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/5d27d1cf00000406> .
+@base <http://model.geneontology.org/5d27d1cf00000407> .
 
-<http://model.geneontology.org/5d27d1cf00000406> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/5d27d1cf00000406> ;
+<http://model.geneontology.org/5d27d1cf00000407> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/5d27d1cf00000407> ;
                                                   owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "GO_shapes Activity unit test 18"^^xsd:string ;
@@ -46,8 +46,8 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000407
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000407> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000407
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000407> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -56,8 +56,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000408
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000408> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/CHEBI_15414> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -65,8 +65,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000409
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000409> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000409
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000409> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -75,8 +75,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000410
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000410> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000410
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000410> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -85,8 +85,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000411
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000411> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000411
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000411> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -95,8 +95,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000412
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000412> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -104,8 +104,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000413
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000413> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/wormbase/WBGene00001865> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -113,16 +113,16 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0009008> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002234> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002413> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002629> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000418> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000419> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000408> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002234> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000416> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000417> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002413> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000422> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002629> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000424> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "358"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "192"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
@@ -132,10 +132,10 @@
                                                                                                    "http://www.wormbase.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000420> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000418> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000420> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -143,10 +143,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000423> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000419> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000423> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -154,10 +154,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002233> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000407> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000408> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000407> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -165,10 +165,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002234> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000415> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000416> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000415> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -176,10 +176,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000421> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000417> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000421> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -187,10 +187,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002413> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000409> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000422> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000409> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -198,18 +198,18 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002629> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000721> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000424> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000721> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000415
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000415> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000415
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000415> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -218,8 +218,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000416
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000416> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/CHEBI_4705> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -227,8 +227,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000417
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000417> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/wormbase/WBGene00017304> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -236,8 +236,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000418
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000418> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0006306> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "75"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "75"^^xsd:string ;
@@ -248,8 +248,8 @@
                                                                                                    "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000419
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000419> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -257,8 +257,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000420
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000420> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000420
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000420> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000315> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -267,8 +267,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000421
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000421> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000421
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000421> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -277,11 +277,11 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000422
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000422> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0003678> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000412> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000413> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "938.9801025390625"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "198.97442245483398"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
@@ -290,10 +290,10 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000422> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000410> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000412> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000410> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -301,10 +301,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000422> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000411> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000413> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000411> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -312,8 +312,8 @@
  ] .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000423
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000423> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000423
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000423> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -322,10 +322,10 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000424
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000424> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0003887> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000685> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "672"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "47"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -333,26 +333,26 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000424> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000720> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000685> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000720> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000685
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000685> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/wormbase/WBGene00003418> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000720
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000720> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000720
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000720> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -360,8 +360,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000721
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000721> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000721
+<http://model.geneontology.org/5d27d1cf00000407/5d27d1cf00000721> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;

--- a/test_ttl/go_cams/should_pass/Test019-happens_during_BiologicalPhase.ttl
+++ b/test_ttl/go_cams/should_pass/Test019-happens_during_BiologicalPhase.ttl
@@ -1,13 +1,13 @@
-@prefix : <http://model.geneontology.org/5d27d1cf00000406#> .
+@prefix : <http://model.geneontology.org/5d27d1cf00000408#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/5d27d1cf00000406> .
+@base <http://model.geneontology.org/5d27d1cf00000408> .
 
-<http://model.geneontology.org/5d27d1cf00000406> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/5d27d1cf00000406> ;
+<http://model.geneontology.org/5d27d1cf00000408> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/5d27d1cf00000408> ;
                                                   owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "GO_shapes Activity unit test 18"^^xsd:string ;
@@ -46,8 +46,8 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000407
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000407> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000407
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000407> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -56,8 +56,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000408
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000408> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/CHEBI_15414> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -65,8 +65,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000409
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000409> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000409
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000409> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -75,8 +75,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000410
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000410> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000410
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000410> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -85,8 +85,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000411
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000411> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000411
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000411> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -95,8 +95,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000412
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000412> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -104,8 +104,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000413
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000413> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/wormbase/WBGene00001865> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -113,16 +113,16 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0009008> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002234> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002413> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002629> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000418> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000419> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000408> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002234> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000416> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000417> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002413> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000422> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002629> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000424> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "358"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "192"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
@@ -132,10 +132,10 @@
                                                                                                    "http://www.wormbase.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000420> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000418> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000420> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -143,10 +143,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000423> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000419> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000423> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -154,10 +154,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002233> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000408> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000407> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000408> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000407> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -165,10 +165,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002234> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000415> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000416> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000415> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -176,10 +176,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000421> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000417> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000421> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -187,10 +187,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002413> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000409> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000422> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000409> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -198,18 +198,18 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000414> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000414> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002629> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000721> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000424> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000721> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000415
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000415> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000415
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000415> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -218,8 +218,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000416> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000416
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000416> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/CHEBI_4705> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -227,8 +227,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000417> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000417
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000417> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/wormbase/WBGene00017304> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -236,8 +236,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000418> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000418
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000418> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0006306> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "75"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "75"^^xsd:string ;
@@ -248,8 +248,8 @@
                                                                                                    "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000419> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000419
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000419> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -257,8 +257,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000420
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000420> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000420
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000420> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000315> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -267,8 +267,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000421
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000421> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000421
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000421> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -277,11 +277,11 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000422
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000422> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0003678> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000412> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000413> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "938.9801025390625"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "198.97442245483398"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
@@ -290,10 +290,10 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000422> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000412> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000410> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000412> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000410> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -301,10 +301,10 @@
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000422> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000422> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000413> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000411> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000413> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000411> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                  "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -312,8 +312,8 @@
  ] .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000423
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000423> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000423
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000423> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-1706-4196"^^xsd:string ,
                                                                                                                 "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -322,10 +322,10 @@
                                                                   <http://purl.org/pav/providedBy> "http://www.wormbase.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000424
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000424> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0003887> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000685> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "672"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "47"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
@@ -333,26 +333,26 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000424> ;
+   owl:annotatedSource <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000424> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000720> ;
+   owl:annotatedTarget <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000685> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000720> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000685> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000685
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000685> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/wormbase/WBGene00003418> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000720
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000720> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000720
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000720> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;
@@ -360,8 +360,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000721
-<http://model.geneontology.org/5d27d1cf00000406/5d27d1cf00000721> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000721
+<http://model.geneontology.org/5d27d1cf00000408/5d27d1cf00000721> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0000314> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0003-1813-6857"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-12"^^xsd:string ;

--- a/test_ttl/go_cams/should_pass/test1.ttl
+++ b/test_ttl/go_cams/should_pass/test1.ttl
@@ -1,17 +1,17 @@
-@prefix : <http://model.geneontology.org/59dc728000000510#> .
+@prefix : <http://model.geneontology.org/59dc728000000511#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/59dc728000000510> .
+@base <http://model.geneontology.org/59dc728000000511> .
 
-<http://model.geneontology.org/59dc728000000510> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000510> ;
+<http://model.geneontology.org/59dc728000000511> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000511> ;
                                                  # owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/pav/providedBy> "http://purl.obolibrary.org/go/groups/IntAct"^^xsd:string ;
-                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000510"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000511"^^xsd:string ;
                                                   rdfs:comment "Ignore this model if you are looking for data"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "Ben's stable demos"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -71,16 +71,16 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00000266
-<http://model.geneontology.org/59dc728000000510/5ce58dde00000266> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00000266
+<http://model.geneontology.org/59dc728000000511/5ce58dde00000266> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-05-31"^^xsd:string ;
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002086
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002086> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002086
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002086> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0097325> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "323"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "82"^^xsd:string ;
@@ -89,8 +89,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002087
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002087> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002087
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002087> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -98,8 +98,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002088
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002088> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002088
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002088> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -107,8 +107,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002089
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002089> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/5ce58dde00002089
+<http://model.geneontology.org/59dc728000000511/5ce58dde00002089> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -116,12 +116,12 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000520
-<http://model.geneontology.org/59dc728000000510/59dc728000000520> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/59dc728000000520
+<http://model.geneontology.org/59dc728000000511/59dc728000000520> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0016874> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000511/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000511/5ce58dde00000266> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000511/59dc728000000521> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "149"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "184"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -130,30 +130,30 @@
                                                                                                    "http://purl.obolibrary.org/go/groups/BHF-UCL"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002088> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00002086> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002088> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002087> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/5ce58dde00000266> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002087> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000511/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002089> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000511/59dc728000000521> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000511/5ce58dde00002089> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string ,
@@ -161,8 +161,8 @@
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000521
-<http://model.geneontology.org/59dc728000000510/59dc728000000521> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000511/59dc728000000521
+<http://model.geneontology.org/59dc728000000511/59dc728000000521> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/Q13253> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2017-12-20"^^xsd:string ;

--- a/test_ttl/go_cams/should_pass/test2.ttl
+++ b/test_ttl/go_cams/should_pass/test2.ttl
@@ -1,17 +1,17 @@
-@prefix : <http://model.geneontology.org/59dc728000000510#> .
+@prefix : <http://model.geneontology.org/59dc728000000512#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://model.geneontology.org/59dc728000000510> .
+@base <http://model.geneontology.org/59dc728000000512> .
 
-<http://model.geneontology.org/59dc728000000510> rdf:type owl:Ontology ;
-                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000510> ;
+<http://model.geneontology.org/59dc728000000512> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/59dc728000000512> ;
                                                   #owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
                                                   <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
                                                   <http://purl.org/pav/providedBy> "http://purl.obolibrary.org/go/groups/IntAct"^^xsd:string ;
-                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000510"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59dc728000000512"^^xsd:string ;
                                                   rdfs:comment "Ignore this model if you are looking for data"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/title> "Ben's stable demos"^^xsd:string ;
                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -71,8 +71,8 @@
 #    Individuals
 #################################################################
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00000266
-<http://model.geneontology.org/59dc728000000510/5ce58dde00000266> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00000266
+<http://model.geneontology.org/59dc728000000512/5ce58dde00000266> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "511"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "237"^^xsd:string ;
@@ -81,8 +81,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002086
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002086> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002086
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002086> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0097325> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "403"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "51"^^xsd:string ;
@@ -91,8 +91,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002088
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002088> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002088
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002088> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -100,8 +100,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002093
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002093> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002093
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002093> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -109,8 +109,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002094
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002094> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002094
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002094> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -118,20 +118,20 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002095
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002095> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002095
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002095> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/P41587> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002096
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002096> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002096
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002096> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0048018> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00002097> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/5ce58dde00002095> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000512/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000512/5ce58dde00002097> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000512/5ce58dde00002095> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "623"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "256"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -139,45 +139,45 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/5ce58dde00002096> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00002086> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/5ce58dde00002096> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002097> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002098> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00002097> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002098> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/5ce58dde00002096> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002095> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002099> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00002095> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002099> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002097
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002097> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002097
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002097> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0005634> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002098
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002098> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002098
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002098> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -185,8 +185,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002099
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002099> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002099
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002099> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -194,8 +194,8 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/5ce58dde00002100
-<http://model.geneontology.org/59dc728000000510/5ce58dde00002100> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/5ce58dde00002100
+<http://model.geneontology.org/59dc728000000512/5ce58dde00002100> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/ECO_0005801> ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
@@ -203,13 +203,13 @@
                                                                   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000520
-<http://model.geneontology.org/59dc728000000510/59dc728000000520> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/59dc728000000520
+<http://model.geneontology.org/59dc728000000512/59dc728000000520> rdf:type owl:NamedIndividual ,
                                                                            <http://purl.obolibrary.org/obo/GO_0016874> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
-                                                                  <http://purl.obolibrary.org/obo/RO_0002411> <http://model.geneontology.org/59dc728000000510/5ce58dde00002096> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59dc728000000512/5ce58dde00002086> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/59dc728000000512/5ce58dde00000266> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59dc728000000512/59dc728000000521> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002411> <http://model.geneontology.org/59dc728000000512/5ce58dde00002096> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "129"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "250"^^xsd:string ;
                                                                   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
@@ -218,38 +218,38 @@
                                                                                                    "http://purl.obolibrary.org/go/groups/BHF-UCL"^^xsd:string .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00002086> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002088> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00002086> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002088> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/5ce58dde00000266> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002093> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/5ce58dde00000266> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002093> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 [ rdf:type owl:Axiom ;
-   owl:annotatedSource <http://model.geneontology.org/59dc728000000510/59dc728000000520> ;
+   owl:annotatedSource <http://model.geneontology.org/59dc728000000512/59dc728000000520> ;
    owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
-   owl:annotatedTarget <http://model.geneontology.org/59dc728000000510/59dc728000000521> ;
-   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000510/5ce58dde00002094> ;
+   owl:annotatedTarget <http://model.geneontology.org/59dc728000000512/59dc728000000521> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59dc728000000512/5ce58dde00002094> ;
    <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-7334-7852"^^xsd:string ;
    <http://purl.org/dc/elements/1.1/date> "2019-07-09"^^xsd:string ;
    <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
  ] .
 
 
-###  http://model.geneontology.org/59dc728000000510/59dc728000000521
-<http://model.geneontology.org/59dc728000000510/59dc728000000521> rdf:type owl:NamedIndividual ,
+###  http://model.geneontology.org/59dc728000000512/59dc728000000521
+<http://model.geneontology.org/59dc728000000512/59dc728000000521> rdf:type owl:NamedIndividual ,
                                                                            <http://identifiers.org/uniprot/Q13253> ;
                                                                   <http://geneontology.org/lego/hint/layout/x> "468.75"^^xsd:string ;
                                                                   <http://geneontology.org/lego/hint/layout/y> "75"^^xsd:string ;


### PR DESCRIPTION
blazegraph can't have more than one model loaded with the same IRI.  If this is attempted, each new attempt over writes the previous one.