### PR TITLE
evidence nodes need metadata in gocamentity

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -489,7 +489,7 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   rdfs:subClassOf [ GoEvidence: ] ;
 }
 
-<Evidence> @<ProvenanceAnnotated> AND EXTRA a  {
+<Evidence> @<GoCamEntity> AND EXTRA a  {
   a @<EvidenceClass> {1};
   source: xsd:string {1};
   with: xsd:string {0,1}


### PR DESCRIPTION
e.g. sometimes they are rendered and need x,y. coordinates to be allowed.