### PR TITLE
add infobiomol to shapemap

### DIFF
--- a/shapes/go-cam-shapes.shapeMap
+++ b/shapes/go-cam-shapes.shapeMap
@@ -1,4 +1,5 @@
 SPARQL 'SELECT ?x WHERE { ?x a <http://www.w3.org/2002/07/owl#Ontology> }' @ <http://purl.obolibrary.org/obo/go/shapes/GoCamModel>,
+SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/CHEBI_33695> }' @ <http://purl.obolibrary.org/obo/go/shapes/InformationBiomacromolecule>,
 SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/NCBITaxon_1> }' @ <http://purl.obolibrary.org/obo/go/shapes/Organism>,
 SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/GO_0003674> }' @ <http://purl.obolibrary.org/obo/go/shapes/MolecularFunction>,
 SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/GO_0005215> }' @ <http://purl.obolibrary.org/obo/go/shapes/TransporterActivity>,


### PR DESCRIPTION
This adds InformationBiomacromolecule to the list of shapes that appear in the go-cam-shapes.shapeMap file.  Why did we not do this before?  I can't remember.. 

The functional consequence as the validation code currently running in Minerva is written is that this will allow for explanations of errors associated with individuals corresponding to genes and proteins in go-cams.  For example, if some one asserted that a gene was a part of a biological process, this change will allow the explanation to come out that genes are not supposed to be part of biological processes.  Without this change, models containing problems like that will still fail to validate, but the explanations won't come out.  
