### PR TITLE
WIP: Changes to date field

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -9,7 +9,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX bl: <https://w3id.org/biolink/vocab/>
 PREFIX contributor: <http://purl.org/dc/elements/1.1/contributor>
 PREFIX provided_by: <http://purl.org/pav/providedBy>
-PREFIX modification_date: <http://purl.org/dc/terms/modified>
+PREFIX modification_date: <http://purl.org/dc/elements/1.1/date>
 PREFIX xref: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
 PREFIX exact_match: <http://www.w3.org/2004/02/skos/core#exactMatch>
 PREFIX source: <http://purl.org/dc/elements/1.1/source>

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -9,7 +9,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX bl: <https://w3id.org/biolink/vocab/>
 PREFIX contributor: <http://purl.org/dc/elements/1.1/contributor>
 PREFIX provided_by: <http://purl.org/pav/providedBy>
-PREFIX date: <http://purl.org/dc/elements/1.1/date>
+PREFIX modification_date: <http://purl.org/dc/terms/modified>
 PREFIX xref: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
 PREFIX exact_match: <http://www.w3.org/2004/02/skos/core#exactMatch>
 PREFIX source: <http://purl.org/dc/elements/1.1/source>
@@ -110,7 +110,7 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
 <GoCamModel> {
   a [owl:Ontology] + ;
   contributor: xsd:string +; #TODO would be better as an IRI
-  date: xsd:string {1}; #TODO can we make this an xsd:date?
+  modification_date: xsd:string {1}; #TODO can we make this an xsd:date or xsd:dateTime? Need to consider all implications.
   provided_by: xsd:string +; #TODO would be better as an IRI
   rdfs:comment xsd:string *;
   modelstate: xsd:string {1}; #TODO would be better as an IRI
@@ -123,7 +123,7 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
 
 <ProvenanceAnnotated> {
   contributor: xsd:string *; #TODO would be better as an IRI
-  date: xsd:string *; #TODO can we make this an xsd:date?
+  modification_date: xsd:string {1}; #TODO can we make this an xsd:date or xsd:dateTime? Need to consider all implications.
   provided_by: xsd:string *; #TODO would be better as an IRI
   rdfs:comment xsd:string *;
   skos:note xsd:string *;


### PR DESCRIPTION
From 2021-07-06 MOD imports call here are the proposed modifications to date field to make explicit that 'date' refers to modification date:

1) Change field label from 'date' to 'modification_date'.
2) Update PREFIX to change 'date' to 'modification_date' and refer to DC term 'modified'.
3) Make cardinality for this field uniformly {1}

Note that we are not changing xsd:string as this field is currently in use and we'll need to consider the consequences of changing to either xsd:date or xsd:dateTime.
The proposed changes here should also not affect the current MOD imports.