### PR TITLE
WIP: Adding creation_date and import_date fields

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -10,6 +10,8 @@ PREFIX bl: <https://w3id.org/biolink/vocab/>
 PREFIX contributor: <http://purl.org/dc/elements/1.1/contributor>
 PREFIX provided_by: <http://purl.org/pav/providedBy>
 PREFIX date: <http://purl.org/dc/elements/1.1/date>
+PREFIX creation_date: <http://purl.org/dc/terms/created>
+PREFIX:import_date: <http://purl.org/dc/terms/dateAccepted>
 PREFIX xref: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
 PREFIX exact_match: <http://www.w3.org/2004/02/skos/core#exactMatch>
 PREFIX source: <http://purl.org/dc/elements/1.1/source>
@@ -111,6 +113,8 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   a [owl:Ontology] + ;
   contributor: xsd:string +; #TODO would be better as an IRI
   date: xsd:string {1}; #TODO can we make this an xsd:date?
+  creation_date: xsd:dateTime {0,1}
+  import_date: xsd:dateTime {0,1}
   provided_by: xsd:string +; #TODO would be better as an IRI
   rdfs:comment xsd:string *;
   modelstate: xsd:string {1}; #TODO would be better as an IRI
@@ -124,6 +128,8 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
 <ProvenanceAnnotated> {
   contributor: xsd:string *; #TODO would be better as an IRI
   date: xsd:string *; #TODO can we make this an xsd:date?
+  creation_date: xsd:dateTime {0,1}
+  import_date: xsd:dateTime {0,1}
   provided_by: xsd:string *; #TODO would be better as an IRI
   rdfs:comment xsd:string *;
   skos:note xsd:string *;

--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -112,9 +112,9 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
 <GoCamModel> {
   a [owl:Ontology] + ;
   contributor: xsd:string +; #TODO would be better as an IRI
-  date: xsd:string {1}; #TODO can we make this an xsd:date?
-  creation_date: xsd:dateTime {0,1}
-  import_date: xsd:dateTime {0,1}
+  date: xsd:string {1}; #Use ISO 8601 as a standard
+  creation_date: xsd:string {0,1} #Use ISO 8601 as a standard
+  import_date: xsd:string {0,1} #Use ISO 8601 as a standard
   provided_by: xsd:string +; #TODO would be better as an IRI
   rdfs:comment xsd:string *;
   modelstate: xsd:string {1}; #TODO would be better as an IRI
@@ -127,9 +127,9 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
 
 <ProvenanceAnnotated> {
   contributor: xsd:string *; #TODO would be better as an IRI
-  date: xsd:string *; #TODO can we make this an xsd:date?
-  creation_date: xsd:dateTime {0,1}
-  import_date: xsd:dateTime {0,1}
+  date: xsd:string *; #Use ISO 8601 as a standard
+  creation_date: xsd:string {0,1} #Use ISO 8601 as a standard
+  import_date: xsd:string {0,1} #Use ISO 8601 as a standard
   provided_by: xsd:string *; #TODO would be better as an IRI
   rdfs:comment xsd:string *;
   skos:note xsd:string *;


### PR DESCRIPTION
From 2021-07-06 MOD imports call, adding creation_date and import_date fields to capture additional metadata about when annotations were created at an external resource and the date on which the annotation was imported into Noctua.  

Specifically:
1) Add PREFIX creation_date and refer to DC term 'created'
2) Add PREFIX import_date and refer to DC term 'dateAccepted'
3) Add these two new fields to both GoCamModel and ProvenanceAnnotated shapes
4) Make cardinality for these two field uniformly {0,1}

Note that these changes will allow us to model additional date information wrt the MOD imports, but otherwise should not affect the current workflows.