### PR TITLE
Adding annotation extension exclusion for 'location of'

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -471,7 +471,7 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
 <AnatomicalEntity> @<GoCamEntity> AND EXTRA a {
   a ( @<AnatomicalEntityClass> OR @<NegatedAnatomicalEntityClass> );
   part_of: @<AnatomicalEntity> {0,1};
-  location_of: ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex> ) {0,1};
+  location_of: ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex> ) {0,1}; * // <exclude_from_extensions> true;
 } // rdfs:comment  "an anatomical entity"
 
 <NativeCellClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {


### PR DESCRIPTION
From discussion on the 2022-12-08 workbenches call, we want to exclude the 'location of' extension relation from the list of allowed CC extensions.

@tmushayahama 