### PR TITLE
Replace CARO anatomical entity with Uberon

### DIFF
--- a/shapes/go-cam-shapes.shex
+++ b/shapes/go-cam-shapes.shex
@@ -61,7 +61,7 @@ prefix GoMolecularEvent: <http://purl.obolibrary.org/obo/go/extensions/reacto.ow
 PREFIX GoTransporterActivity: <http://purl.obolibrary.org/obo/GO_0005215>
 PREFIX GoChemicalEntity: <http://purl.obolibrary.org/obo/CHEBI_24431>
 PREFIX GoEvidence: <http://purl.obolibrary.org/obo/ECO_0000000>
-PREFIX GoAnatomicalEntity: <http://purl.obolibrary.org/obo/CARO_0000000>
+PREFIX GoAnatomicalEntity: <http://purl.obolibrary.org/obo/UBERON_0001062>
 PREFIX GoNativeCell: <http://purl.obolibrary.org/obo/CL_0000003>
 PREFIX GoOrganism: <http://purl.obolibrary.org/obo/NCBITaxon_1>
 PREFIX GoBiologicalPhase: <http://purl.obolibrary.org/obo/GO_0044848>


### PR DESCRIPTION
We are replacing CARO with Uberon terms globally (see https://github.com/obophenotype/uberon/issues/2349 and https://github.com/oborel/obo-relations/issues/695 and https://github.com/geneontology/go-ontology/issues/25485).

I have a PR in Minerva to return Uberon 'anatomical entity' as a root type (https://github.com/geneontology/minerva/pull/515). Once that is deployed, Noctua should switch over to using the Uberon term rather than the CARO term (https://github.com/geneontology/noctua/issues/838). We should merge this around the same time.